### PR TITLE
🌱 Use `GITHUB_TOKEN` instead of PAT

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -31,7 +31,7 @@ jobs:
           results_format: sarif
           # Read-only PAT token. To create it,
           # follow the steps in https://github.com/ossf/scorecard-action#pat-token-creation.
-          repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           # Publish the results to enable scorecard badges. For more details, see
           # https://github.com/ossf/scorecard-action#publishing-results.
           # If you are installing the action on a private repo, set it to `publish_results: false` 


### PR DESCRIPTION
Temporarily disable PAT and use `GITHUB_TOKEN` instead.