### PR TITLE
🌱 Setup api.securityscorecards.dev

### DIFF
--- a/k8s.yaml
+++ b/k8s.yaml
@@ -22,6 +22,16 @@ spec:
   - www.securityscorecards.dev
 ---
 
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: scorecard-api-managed-cert
+spec:
+  domains:
+  - api.securityscorecards.dev
+---
+
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -29,6 +39,22 @@ metadata:
   annotations:
     kubernetes.io/ingress.global-static-ip-name: scorecard-webapp
     networking.gke.io/managed-certificates: scorecard-webapp-managed-cert
+    kubernetes.io/ingress.class: "gce"
+spec:
+  defaultBackend:
+    service:
+      name: scorecard-webapp-service
+      port:
+        number: 80
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: scorecard-api-ingress
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: scorecard-api
+    networking.gke.io/managed-certificates: scorecard-api-managed-cert
     kubernetes.io/ingress.class: "gce"
 spec:
   defaultBackend:


### PR DESCRIPTION
Setup https://api.securityscorecards.dev. This will be used by @rohankh532 to return `POST` and `GET` Scorecard results.

How it will work:

- Scorecard GitHub Action will make the call `POST https://api.securityscorecards.dev` (with the right payload) to verify and store the result.

- A publicly accessible endpoint can call `GET https://api.securityscorecards.dev/{platform}/{org}/{name}` to get the latest stored Scorecard result. E.g `GET https://api.securityscorecards.dev/github.com/ossf/scorecard`.

- Use the `GET` API in `sheilds.io`.

@rohankh532 fyi.