### PR TITLE
🌱 Dependabot PRs reviewed by scorecard-maintainers

### DIFF
--- a/scorecards-site/.github/dependabot.yml
+++ b/scorecards-site/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
       time: '00:00'
     open-pull-requests-limit: 10
     reviewers:
-      - mdunbavan
+      - ossf/scorecard-maintainers
     assignees:
-      - mdunbavan
+      - ossf/scorecard-maintainers
     commit-message:
       prefix: fix
       prefix-development: chore
@@ -23,9 +23,9 @@ updates:
       time: '00:00'
     open-pull-requests-limit: 10
     reviewers:
-      - mdunbavan
+      - ossf/scorecard-maintainers
     assignees:
-      - mdunbavan
+      - ossf/scorecard-maintainers
     commit-message:
       prefix: fix
       prefix-development: chore


### PR DESCRIPTION
Changing the reviewer for dependabot PRs to be scorecard-maintainers.