### PR TITLE
🐛 Fix bug in uuid lookup

### DIFF
--- a/app/post_results.go
+++ b/app/post_results.go
@@ -339,7 +339,7 @@ func getTLogEntry(ctx context.Context, uuid string) (*tlogEntry, error) {
 		return nil, fmt.Errorf("decoding Rekor response: %w", err)
 	}
 
-	if res, exists := rekorResult[uuid]; exists {
+	for _, res := range rekorResult {
 		return &res, nil
 	}
 	return nil, fmt.Errorf("unexpected error: entry for uuid %s not found", uuid)


### PR DESCRIPTION
It is not guaranteed that the response from Rekor API - `map{ "uuid": "tlogEntry" }` will match the uuid that was requested due to some extra sharding bits being attached. So removing that logic. 