### PR TITLE
🐛 Fix the job permission for Scorecard action

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
-    
+      id-token: write
     steps:
       - name: "Checkout code"
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0


### PR DESCRIPTION
There was no `id-token` permission defined for GitHub workflow which Scorecard badge requires.