### PR TITLE
✨ Record and return per-commit results in API

### DIFF
--- a/app/get_results_test.go
+++ b/app/get_results_test.go
@@ -28,6 +28,7 @@ func TestSanitizePath(t *testing.T) {
 		host     string
 		orgName  string
 		repoName string
+		commit   string
 		wantPath string
 		wantErr  error
 	}{
@@ -59,12 +60,20 @@ func TestSanitizePath(t *testing.T) {
 			repoName: "repo",
 			wantErr:  errInvalidInputs,
 		},
+		{
+			name:     "handles commit",
+			host:     "github.com",
+			orgName:  "org",
+			repoName: "repo",
+			commit:   "sha1",
+			wantPath: "github.com/org/repo/sha1/results.json",
+		},
 	}
 	for _, tt := range testcases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			gotPath, gotErr := sanitizeInputs(tt.host, tt.orgName, tt.repoName)
+			gotPath, gotErr := sanitizeInputs(tt.host, tt.orgName, tt.repoName, tt.commit)
 			if !errors.Is(gotErr, tt.wantErr) {
 				t.Errorf("expected %v, got %v", tt.wantErr, gotErr)
 			}

--- a/app/post_results.go
+++ b/app/post_results.go
@@ -177,10 +177,15 @@ func processRequest(host, org, repo string, scorecardResult ScorecardResult) err
 	// Save scorecard results (results.json, score.txt) to GCS
 	bucketURL := resultsBucket
 	objectPath := fmt.Sprintf("%s/%s/%s/%s", host, org, repo, resultsFile)
-
 	if err := writeToBlobStore(ctx, bucketURL, objectPath, []byte(scorecardResult.Result)); err != nil {
-		return fmt.Errorf(errWritingBucket.Error()+": %v, %v", err)
+		return fmt.Errorf("%w: %v", errWritingBucket, err)
 	}
+
+	commitObjectPath := fmt.Sprintf("%s/%s/%s/%s/%s", host, org, repo, info.repoSHA, resultsFile)
+	if err := writeToBlobStore(ctx, bucketURL, commitObjectPath, []byte(scorecardResult.Result)); err != nil {
+		return fmt.Errorf("%w: %v", errWritingBucket, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR records per-commit info during POST request and updates the GET request to support `?commit=` URL param. The PR also adds support to lookup cron results as a backup mechanism when scorecard-action results are unavailable.