### PR TITLE
✨ Setup Cloud Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,23 @@ changes committed to [openapi.yaml](./openapi.yaml) on the `main` branch gets
 deployed to the staging site only. To make changes to the production API, a new
 Git tag needs to be generated which will auto deploy the latest tag to
 production.
+
+### TODO: automate these steps
+
+Any updates made to [openapi.yaml](./openapi.yaml) needs to be deployed onto
+Google Cloud Endpoints. To do that, follow these steps:
+
+```
+$ gcloud auth login
+$ gcloud endpoints services deploy openapi.yaml --project openssf --quiet --format=json > /tmp/gcloud.json
+$ wget https://raw.githubusercontent.com/GoogleCloudPlatform/esp-v2/master/docker/serverless/gcloud_build_image \
+   --output-document=/tmp/gcloud_build_image
+$ chmod +x /tmp/gcloud_build_image
+$ /tmp/gcloud_build_image -c $(cat /tmp/gcloud.json | jq -r .serviceConfig.id) \
+   -s $(cat /tmp/gcloud.json | jq -r .serviceConfig.name) \
+   -p openssf -z us
+$ gcloud run deploy scorecard-endpoints-prod \
+   --image=<image-from-above-step> \
+   --project=openssf
+   # For region prompt, choose us-central1.
+```

--- a/app/generated/restapi/configure_scorecard.go
+++ b/app/generated/restapi/configure_scorecard.go
@@ -120,6 +120,9 @@ func serveStatic(handler http.Handler) http.Handler {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
+			if r.URL.Path == "/" {
+				w.Header().Add("content-type", "text/html")
+			}
 			http.FileServer(http.FS(static)).ServeHTTP(w, r)
 			return
 		}

--- a/app/generated/restapi/embedded_spec.go
+++ b/app/generated/restapi/embedded_spec.go
@@ -325,6 +325,11 @@ func init() {
     "NotFound": {
       "description": "The content requested could not be found"
     }
+  },
+  "x-google-allow": "all",
+  "x-google-backend": {
+    "address": "https://scorecard-api-prod-x3pmld2cbq-uc.a.run.app",
+    "protocol": "h2"
   }
 }`))
 	FlatSwaggerJSON = json.RawMessage([]byte(`{
@@ -647,6 +652,11 @@ func init() {
     "NotFound": {
       "description": "The content requested could not be found"
     }
+  },
+  "x-google-allow": "all",
+  "x-google-backend": {
+    "address": "https://scorecard-api-prod-x3pmld2cbq-uc.a.run.app",
+    "protocol": "h2"
   }
 }`))
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26,10 +26,10 @@ consumes:
 produces:
   - application/json
 
-# TODO(azeems): Enable this when using it for Cloud Endpoints.
-#x-google-backend:
-#address: https://scorecard-api-prod-x3pmld2cbq-uc.a.run.app
-#protocol: h2
+x-google-backend:
+  address: https://scorecard-api-prod-x3pmld2cbq-uc.a.run.app
+  protocol: h2
+x-google-allow: all
 
 paths:
   /projects/{platform}/{org}/{repo}/badge:


### PR DESCRIPTION
This PR sets up Cloud Endpoints as a load balancer for the API. In follow up PRs, the load balancer can be used to throttle requests.

Part of https://github.com/ossf/scorecard-action/issues/765