### PR TITLE
🌱 Format API JSON output

### DIFF
--- a/app/generated/restapi/configure_scorecard.go
+++ b/app/generated/restapi/configure_scorecard.go
@@ -41,12 +41,8 @@ import (
 var (
 	//go:embed static
 	staticDir  embed.FS
-	jsonIndent string
+	jsonIndent = flag.String("indent", "", "the indent used in json output (default no ident \"\")")
 )
-
-func init() {
-	flag.StringVar(&jsonIndent, "indent", "", "the indent used in json output (default no ident \"\")")
-}
 
 func configureFlags(api *operations.ScorecardAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }
@@ -69,7 +65,7 @@ func configureAPI(api *operations.ScorecardAPI) http.Handler {
 	api.JSONConsumer = runtime.JSONConsumer()
 	api.JSONProducer = runtime.ProducerFunc(func(writer io.Writer, data interface{}) error {
 		enc := json.NewEncoder(writer)
-		enc.SetIndent("", jsonIndent)
+		enc.SetIndent("", *jsonIndent)
 		enc.SetEscapeHTML(false)
 		return enc.Encode(data)
 	})

--- a/app/generated/restapi/configure_scorecard.go
+++ b/app/generated/restapi/configure_scorecard.go
@@ -19,6 +19,8 @@ package restapi
 import (
 	"crypto/tls"
 	"embed"
+	"encoding/json"
+	"io"
 	"io/fs"
 	"net/http"
 
@@ -57,7 +59,12 @@ func configureAPI(api *operations.ScorecardAPI) http.Handler {
 	// api.UseRedoc()
 
 	api.JSONConsumer = runtime.JSONConsumer()
-	api.JSONProducer = runtime.JSONProducer()
+	api.JSONProducer = runtime.ProducerFunc(func(writer io.Writer, data interface{}) error {
+		enc := json.NewEncoder(writer)
+		enc.SetIndent("", jsonIndent)
+		enc.SetEscapeHTML(false)
+		return enc.Encode(data)
+	})
 
 	api.ResultsGetResultHandler = results.GetResultHandlerFunc(server.GetResultHandler)
 	api.ResultsPostResultHandler = results.PostResultHandlerFunc(server.PostResultsHandler)

--- a/app/generated/restapi/configure_scorecard.go
+++ b/app/generated/restapi/configure_scorecard.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/rs/cors"
+	flag "github.com/spf13/pflag"
 
 	"github.com/ossf/scorecard-webapp/app/generated/restapi/operations"
 	"github.com/ossf/scorecard-webapp/app/generated/restapi/operations/badge"
@@ -37,8 +38,15 @@ import (
 //nolint:lll // generated code
 //go:generate swagger generate server --target ../../generated --name Scorecard --spec ../../../openapi.yaml --principal interface{}
 
-//go:embed static
-var staticDir embed.FS
+var (
+	//go:embed static
+	staticDir  embed.FS
+	jsonIndent string
+)
+
+func init() {
+	flag.StringVar(&jsonIndent, "indent", "", "the indent used in json output (default no ident \"\")")
+}
 
 func configureFlags(api *operations.ScorecardAPI) {
 	// api.CommandLineOptionsGroups = []swag.CommandLineOptionsGroup{ ... }

--- a/app/generated/restapi/server.go
+++ b/app/generated/restapi/server.go
@@ -80,6 +80,8 @@ var (
 	tlsCertificate    string
 	tlsCertificateKey string
 	tlsCACertificate  string
+
+	jsonIndent string
 )
 
 func init() {
@@ -109,6 +111,8 @@ func init() {
 	flag.DurationVar(&tlsKeepAlive, "tls-keep-alive", 3*time.Minute, "sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)")
 	flag.DurationVar(&tlsReadTimeout, "tls-read-timeout", 30*time.Second, "maximum duration before timing out read of the request")
 	flag.DurationVar(&tlsWriteTimeout, "tls-write-timeout", 30*time.Second, "maximum duration before timing out write of the response")
+	
+	flag.StringVar(&jsonIndent, "indent", "", "the indent used in json output (default no ident \"\")")
 }
 
 func stringEnvOverride(orig string, def string, keys ...string) string {

--- a/app/generated/restapi/server.go
+++ b/app/generated/restapi/server.go
@@ -80,8 +80,6 @@ var (
 	tlsCertificate    string
 	tlsCertificateKey string
 	tlsCACertificate  string
-
-	jsonIndent string
 )
 
 func init() {
@@ -111,8 +109,6 @@ func init() {
 	flag.DurationVar(&tlsKeepAlive, "tls-keep-alive", 3*time.Minute, "sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)")
 	flag.DurationVar(&tlsReadTimeout, "tls-read-timeout", 30*time.Second, "maximum duration before timing out read of the request")
 	flag.DurationVar(&tlsWriteTimeout, "tls-write-timeout", 30*time.Second, "maximum duration before timing out write of the response")
-	
-	flag.StringVar(&jsonIndent, "indent", "", "the indent used in json output (default no ident \"\")")
 }
 
 func stringEnvOverride(orig string, def string, keys ...string) string {


### PR DESCRIPTION
Partially addresses #206 

Originally proposed in https://github.com/ossf/scorecard/pull/2251, but the JSON marshalling/unmarshalling in the webapp would overrule any change made there.

It's introduced as a flag, where the default is no indentation / pretty printing. This matches the current behavior.
I'm unfamiliar with CloudRun, so if it's hard to specify in the production deployment a static value can be used.

```
./scorecard-webapp -h
Usage:
  scorecard-server [OPTIONS]

OpenSSF Scorecard API

API to interact with a project's published Scorecard result

      --cleanup-timeout duration     grace period for which to wait before killing idle connections (default 10s)
      --graceful-timeout duration    grace period for which to wait before shutting down the server (default 15s)
      --host string                  the IP to listen on (default "localhost")
      --indent string                the indent used in json output (default no ident "")

...
```