### PR TITLE
:seedling: Match JSON output produced by Scorecard

### DIFF
--- a/app/generated/models/scorecard_check.go
+++ b/app/generated/models/scorecard_check.go
@@ -33,8 +33,8 @@ import (
 // swagger:model ScorecardCheck
 type ScorecardCheck struct {
 
-	// name
-	Name string `json:"name,omitempty"`
+	// details
+	Details []string `json:"details"`
 
 	// score
 	Score int64 `json:"score"`
@@ -42,8 +42,8 @@ type ScorecardCheck struct {
 	// reason
 	Reason string `json:"reason,omitempty"`
 
-	// details
-	Details []string `json:"details"`
+	// name
+	Name string `json:"name,omitempty"`
 
 	// documentation
 	Documentation *ScorecardCheckDocumentation `json:"documentation,omitempty"`

--- a/app/generated/models/scorecard_check.go
+++ b/app/generated/models/scorecard_check.go
@@ -135,11 +135,11 @@ func (m *ScorecardCheck) UnmarshalBinary(b []byte) error {
 // swagger:model ScorecardCheckDocumentation
 type ScorecardCheckDocumentation struct {
 
-	// short
-	Short string `json:"short,omitempty"`
-
 	// url
 	URL string `json:"url,omitempty"`
+
+	// short
+	Short string `json:"short,omitempty"`
 }
 
 // Validate validates this scorecard check documentation

--- a/app/generated/models/scorecard_result.go
+++ b/app/generated/models/scorecard_result.go
@@ -50,7 +50,7 @@ type ScorecardResult struct {
 	Checks []*ScorecardCheck `json:"checks"`
 
 	// metadata
-	Metadata string `json:"metadata,omitempty"`
+	Metadata *string `json:"metadata"`
 }
 
 // Validate validates this scorecard result

--- a/app/generated/restapi/embedded_spec.go
+++ b/app/generated/restapi/embedded_spec.go
@@ -230,7 +230,7 @@ func init() {
           "items": {
             "type": "string"
           },
-          "x-order": 4
+          "x-order": 0
         },
         "documentation": {
           "type": "object",
@@ -242,11 +242,11 @@ func init() {
               "type": "string"
             }
           },
-          "x-order": 3
+          "x-order": 4
         },
         "name": {
           "type": "string",
-          "x-order": 0
+          "x-order": 3
         },
         "reason": {
           "type": "string",
@@ -561,7 +561,7 @@ func init() {
           "items": {
             "type": "string"
           },
-          "x-order": 4
+          "x-order": 0
         },
         "documentation": {
           "type": "object",
@@ -573,11 +573,11 @@ func init() {
               "type": "string"
             }
           },
-          "x-order": 3
+          "x-order": 4
         },
         "name": {
           "type": "string",
-          "x-order": 0
+          "x-order": 3
         },
         "reason": {
           "type": "string",
@@ -600,7 +600,7 @@ func init() {
           "type": "string"
         }
       },
-      "x-order": 3
+      "x-order": 4
     },
     "ScorecardResult": {
       "type": "object",

--- a/app/generated/restapi/embedded_spec.go
+++ b/app/generated/restapi/embedded_spec.go
@@ -236,10 +236,12 @@ func init() {
           "type": "object",
           "properties": {
             "short": {
-              "type": "string"
+              "type": "string",
+              "x-order": 1
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "x-order": 0
             }
           },
           "x-order": 4
@@ -275,6 +277,8 @@ func init() {
         },
         "metadata": {
           "type": "string",
+          "x-nullable": true,
+          "x-omitempty": false,
           "x-order": 5
         },
         "repo": {
@@ -567,10 +571,12 @@ func init() {
           "type": "object",
           "properties": {
             "short": {
-              "type": "string"
+              "type": "string",
+              "x-order": 1
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "x-order": 0
             }
           },
           "x-order": 4
@@ -594,10 +600,12 @@ func init() {
       "type": "object",
       "properties": {
         "short": {
-          "type": "string"
+          "type": "string",
+          "x-order": 1
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "x-order": 0
         }
       },
       "x-order": 4
@@ -618,6 +626,8 @@ func init() {
         },
         "metadata": {
           "type": "string",
+          "x-nullable": true,
+          "x-omitempty": false,
           "x-order": 5
         },
         "repo": {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -198,9 +198,11 @@ definitions:
   ScorecardCheck:
     type: object
     properties:
-      name:
-        type: string
+      details:
+        type: array
         x-order: 0
+        items:
+          type: string
       score:
         type: integer
         x-omitempty: false
@@ -208,19 +210,17 @@ definitions:
       reason:
         type: string
         x-order: 2
+      name:
+        type: string
+        x-order: 3
       documentation:
         type: object
-        x-order: 3
+        x-order: 4
         properties:
           url:
             type: string
           short:
             type: string
-      details:
-        type: array
-        x-order: 4
-        items:
-          type: string
 
   VerifiedScorecardResult:
     type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -167,6 +167,8 @@ definitions:
           $ref: '#/definitions/ScorecardCheck'
       metadata:
         type: string
+        x-nullable: true
+        x-omitempty: false
         x-order: 5
 
   Repo:
@@ -219,8 +221,10 @@ definitions:
         properties:
           url:
             type: string
+            x-order: 0
           short:
             type: string
+            x-order: 1
 
   VerifiedScorecardResult:
     type: object


### PR DESCRIPTION
Changed the ordering and properties of fields so that the JSON served by the webapp will match the JSON output from `scorecard` as defined here (including order of subtypes)
https://github.com/ossf/scorecard/blob/46c6fe700cdc10a780f3c867b36b6810e1986cb0/pkg/json.go#L81-L88
This helps when hashing the file in order to find the file in the Rekor transparency log.

All changes were made to `openapi.yaml` and the other files were generated via `make swagger`.