### PR TITLE
:seedling: Disable depguard linter and pin golangci-lint-action.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,15 +37,15 @@ jobs:
       contents: read
     steps:
      - name: Clone the code
-       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v2.3.4
+       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
        with:
           fetch-depth: 0
      - name: Setup Go
-       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v2.2.0
+       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
        with:
          go-version: ${{ env.GO_VERSION }}
      - name: Run linter
-       uses: golangci/golangci-lint-action@v3
+       uses: golangci/golangci-lint-action@5f1fec7010f6ae3b84ea4f7b2129beb8639b564f # v3.5.0
        with:
          args: --config=.golangci.yml
      - name: Check license headers

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
   disable-all: true
   enable:
     - asciicheck
-    - depguard
     - dogsled
     - exhaustive
     - exportloopref


### PR DESCRIPTION
golangci-lint-action had a release which changed some behavior in depguard and is causing the linter to fail now:
https://github.com/ossf/scorecard-webapp/actions/runs/5152614093/jobs/9287923800

We don't appear to be using depguard (we have no `.depguard.yml` file or similar), so might as well disable it.