### PR TITLE
:bug: Surface workflow verification errors with doc link

### DIFF
--- a/app/server/post_results.go
+++ b/app/server/post_results.go
@@ -113,7 +113,7 @@ func PostResultsHandler(params results.PostResultParams) middleware.Responder {
 	if errors.Is(err, errMismatchedCertAndRequest) || errors.Is(err, errWorkflowVerification) {
 		return results.NewPostResultBadRequest().WithPayload(&models.Error{
 			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("Workflow validation failed, see %s for details. %v", workflowRestrictionLink, err),
+			Message: fmt.Sprintf("%v, see %s for details.", err, workflowRestrictionLink),
 		})
 	}
 	log.Println(err)

--- a/app/server/post_results.go
+++ b/app/server/post_results.go
@@ -137,7 +137,7 @@ func processRequest(host, org, repo string, scorecardResult *models.VerifiedScor
 	if info.repoFullName != fullName(org, repo) ||
 		(info.repoBranchRef != scorecardResult.Branch &&
 			info.repoBranchRef != fmt.Sprintf("refs/heads/%s", scorecardResult.Branch)) {
-		return fmt.Errorf("%w", errMismatchedCertAndRequest)
+		return errMismatchedCertAndRequest
 	}
 
 	if err := getAndVerifyWorkflowContent(ctx, scorecardResult, info); err != nil {
@@ -274,7 +274,7 @@ func extractAndVerifyCertForPayload(ctx context.Context, payload []byte) (*x509.
 		return nil, fmt.Errorf("error extracting certificate from entry: %w", err)
 	}
 	if len(certs) > 1 {
-		return nil, fmt.Errorf("%w", errMultipleCerts)
+		return nil, errMultipleCerts
 	}
 
 	cert := certs[0]

--- a/app/server/post_results.go
+++ b/app/server/post_results.go
@@ -47,11 +47,12 @@ import (
 const (
 	// OID source: https://github.com/sigstore/fulcio/blob/96ef49cc7662912ba37d46f738757e8d8d5b5355/docs/oid-info.md#L33
 	// TODO: retrieve these by name.
-	fulcioRepoRefKey  = "1.3.6.1.4.1.57264.1.6"
-	fulcioRepoPathKey = "1.3.6.1.4.1.57264.1.5"
-	fulcioRepoSHAKey  = "1.3.6.1.4.1.57264.1.3"
-	resultsBucket     = "gs://ossf-scorecard-results"
-	resultsFile       = "results.json"
+	fulcioRepoRefKey        = "1.3.6.1.4.1.57264.1.6"
+	fulcioRepoPathKey       = "1.3.6.1.4.1.57264.1.5"
+	fulcioRepoSHAKey        = "1.3.6.1.4.1.57264.1.3"
+	resultsBucket           = "gs://ossf-scorecard-results"
+	resultsFile             = "results.json"
+	workflowRestrictionLink = "https://github.com/ossf/scorecard-action#workflow-restrictions"
 )
 
 var (
@@ -112,7 +113,7 @@ func PostResultsHandler(params results.PostResultParams) middleware.Responder {
 	if errors.Is(err, errMismatchedCertAndRequest) || errors.Is(err, errWorkflowVerification) {
 		return results.NewPostResultBadRequest().WithPayload(&models.Error{
 			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("Your request failed validation. See foo.bar/explanation.md for details. %v", err),
+			Message: fmt.Sprintf("Workflow validation failed, see %s for details. %v", workflowRestrictionLink, err),
 		})
 	}
 	log.Println(err)
@@ -141,7 +142,7 @@ func processRequest(host, org, repo string, scorecardResult *models.VerifiedScor
 
 	if err := getAndVerifyWorkflowContent(ctx, scorecardResult, info); err != nil {
 		// TODO(go 1.20) wrap multiple errors https://go.dev/doc/go1.20#errors
-		return fmt.Errorf("%w: %v", errWorkflowVerification, err.Error())
+		return fmt.Errorf("%w: %v", errWorkflowVerification, err)
 	}
 
 	// Save scorecard results (results.json, score.txt) to GCS


### PR DESCRIPTION
Should resolve https://github.com/ossf/scorecard-action/issues/1150 once a new webapp release is cut. The underlying logic always existed for POST requests, but the implementation wasn't working due to a `%v` instead of a `%w` here:
https://github.com/ossf/scorecard-webapp/blob/9c2f66d5f6ff56ca4a4ac2fba6ec8dcc5379d31c/app/server/post_results.go#L233-L236

After testing locally, I received the following response to the issue reporter's POST data:
```
{
  "code": 400,
  "message": "workflow verification failed: workflow contains global env vars or defaults, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."
}
```

