### PR TITLE
Revert ":seedling: Match JSON output produced by Scorecard"

### DIFF
--- a/app/generated/models/scorecard_check.go
+++ b/app/generated/models/scorecard_check.go
@@ -33,8 +33,8 @@ import (
 // swagger:model ScorecardCheck
 type ScorecardCheck struct {
 
-	// details
-	Details []string `json:"details"`
+	// name
+	Name string `json:"name,omitempty"`
 
 	// score
 	Score int64 `json:"score"`
@@ -42,8 +42,8 @@ type ScorecardCheck struct {
 	// reason
 	Reason string `json:"reason,omitempty"`
 
-	// name
-	Name string `json:"name,omitempty"`
+	// details
+	Details []string `json:"details"`
 
 	// documentation
 	Documentation *ScorecardCheckDocumentation `json:"documentation,omitempty"`
@@ -135,11 +135,11 @@ func (m *ScorecardCheck) UnmarshalBinary(b []byte) error {
 // swagger:model ScorecardCheckDocumentation
 type ScorecardCheckDocumentation struct {
 
-	// url
-	URL string `json:"url,omitempty"`
-
 	// short
 	Short string `json:"short,omitempty"`
+
+	// url
+	URL string `json:"url,omitempty"`
 }
 
 // Validate validates this scorecard check documentation

--- a/app/generated/models/scorecard_result.go
+++ b/app/generated/models/scorecard_result.go
@@ -50,7 +50,7 @@ type ScorecardResult struct {
 	Checks []*ScorecardCheck `json:"checks"`
 
 	// metadata
-	Metadata *string `json:"metadata"`
+	Metadata string `json:"metadata,omitempty"`
 }
 
 // Validate validates this scorecard result

--- a/app/generated/restapi/embedded_spec.go
+++ b/app/generated/restapi/embedded_spec.go
@@ -230,25 +230,23 @@ func init() {
           "items": {
             "type": "string"
           },
-          "x-order": 0
+          "x-order": 4
         },
         "documentation": {
           "type": "object",
           "properties": {
             "short": {
-              "type": "string",
-              "x-order": 1
+              "type": "string"
             },
             "url": {
-              "type": "string",
-              "x-order": 0
+              "type": "string"
             }
           },
-          "x-order": 4
+          "x-order": 3
         },
         "name": {
           "type": "string",
-          "x-order": 3
+          "x-order": 0
         },
         "reason": {
           "type": "string",
@@ -277,8 +275,6 @@ func init() {
         },
         "metadata": {
           "type": "string",
-          "x-nullable": true,
-          "x-omitempty": false,
           "x-order": 5
         },
         "repo": {
@@ -565,25 +561,23 @@ func init() {
           "items": {
             "type": "string"
           },
-          "x-order": 0
+          "x-order": 4
         },
         "documentation": {
           "type": "object",
           "properties": {
             "short": {
-              "type": "string",
-              "x-order": 1
+              "type": "string"
             },
             "url": {
-              "type": "string",
-              "x-order": 0
+              "type": "string"
             }
           },
-          "x-order": 4
+          "x-order": 3
         },
         "name": {
           "type": "string",
-          "x-order": 3
+          "x-order": 0
         },
         "reason": {
           "type": "string",
@@ -600,15 +594,13 @@ func init() {
       "type": "object",
       "properties": {
         "short": {
-          "type": "string",
-          "x-order": 1
+          "type": "string"
         },
         "url": {
-          "type": "string",
-          "x-order": 0
+          "type": "string"
         }
       },
-      "x-order": 4
+      "x-order": 3
     },
     "ScorecardResult": {
       "type": "object",
@@ -626,8 +618,6 @@ func init() {
         },
         "metadata": {
           "type": "string",
-          "x-nullable": true,
-          "x-omitempty": false,
           "x-order": 5
         },
         "repo": {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -167,8 +167,6 @@ definitions:
           $ref: '#/definitions/ScorecardCheck'
       metadata:
         type: string
-        x-nullable: true
-        x-omitempty: false
         x-order: 5
 
   Repo:
@@ -200,11 +198,9 @@ definitions:
   ScorecardCheck:
     type: object
     properties:
-      details:
-        type: array
+      name:
+        type: string
         x-order: 0
-        items:
-          type: string
       score:
         type: integer
         x-omitempty: false
@@ -212,19 +208,19 @@ definitions:
       reason:
         type: string
         x-order: 2
-      name:
-        type: string
-        x-order: 3
       documentation:
         type: object
-        x-order: 4
+        x-order: 3
         properties:
           url:
             type: string
-            x-order: 0
           short:
             type: string
-            x-order: 1
+      details:
+        type: array
+        x-order: 4
+        items:
+          type: string
 
   VerifiedScorecardResult:
     type: object


### PR DESCRIPTION
Reverts ossf/scorecard-webapp#377

The openAPI spec are being used in a way that releasing this change would be a breaking change, both inside the Go ecosystem and outside.

https://github.com/jetstack/tally/blob/54a465ebd3d5c729d0c5529c5125b517e8e4f0b4/go.mod#L12
https://github.com/NodeSecure/ossf-scorecard-sdk/blob/ff5f8d5b5d698760c373aeff84fd0b99602dd9b3/src/index.ts#L19-L21

I don't think the re-ordering parts are a breaking change, but without the `metadata` changes, the SHAs (of the API output and the JSON uploaded to the rekor transparency log) won't match the original scorecard output so I'm just reverting the whole PR.


I still think the change is worth doing eventually, once we figure out how to make (small) breaking changes to the API.