### PR TITLE
:seedling: Fix dependabot config indentation.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,14 @@ version: 2
 updates:
   # For API code in app/
   - package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  commit-message:
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
       prefix: ":seedling:"
-  reviewers:
-    - "ossf/scorecard-maintainers"
-  open-pull-requests-limit: 10
+    reviewers:
+      - "ossf/scorecard-maintainers"
+    open-pull-requests-limit: 10
   # For the website code in scorecards-site.
   - package-ecosystem: npm
     directory: '/'


### PR DESCRIPTION
Indentation was invalid during #166.
Dependabot complains only when pushed to main (https://github.com/ossf/scorecard-webapp/runs/15991713628). Which  is a known issue: https://github.com/dependabot/dependabot-core/issues/4605

I've validated the indentation locally with a YAML linter.