### PR TITLE
:bug: Specify badge endpoints returns content-type image/svg+xml

### DIFF
--- a/app/generated/client/badge/badge_client.go
+++ b/app/generated/client/badge/badge_client.go
@@ -60,7 +60,7 @@ func (a *Client) GetBadge(params *GetBadgeParams, opts ...ClientOption) error {
 		ID:                 "getBadge",
 		Method:             "GET",
 		PathPattern:        "/projects/{platform}/{org}/{repo}/badge",
-		ProducesMediaTypes: []string{"application/json"},
+		ProducesMediaTypes: []string{"image/svg+xml"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http"},
 		Params:             params,

--- a/app/generated/restapi/doc.go
+++ b/app/generated/restapi/doc.go
@@ -27,6 +27,7 @@
 //	  - application/json
 //
 //	Produces:
+//	  - image/svg+xml
 //	  - application/json
 //
 // swagger:meta

--- a/app/generated/restapi/embedded_spec.go
+++ b/app/generated/restapi/embedded_spec.go
@@ -141,6 +141,9 @@ func init() {
     },
     "/projects/{platform}/{org}/{repo}/badge": {
       "get": {
+        "produces": [
+          "image/svg+xml"
+        ],
         "tags": [
           "badge"
         ],
@@ -472,6 +475,9 @@ func init() {
     },
     "/projects/{platform}/{org}/{repo}/badge": {
       "get": {
+        "produces": [
+          "image/svg+xml"
+        ],
         "tags": [
           "badge"
         ],

--- a/app/generated/restapi/operations/scorecard_api.go
+++ b/app/generated/restapi/operations/scorecard_api.go
@@ -58,6 +58,7 @@ func NewScorecardAPI(spec *loads.Document) *ScorecardAPI {
 
 		JSONConsumer: runtime.JSONConsumer(),
 
+		BinProducer:  runtime.ByteStreamProducer(),
 		JSONProducer: runtime.JSONProducer(),
 
 		BadgeGetBadgeHandler: badge.GetBadgeHandlerFunc(func(params badge.GetBadgeParams) middleware.Responder {
@@ -101,6 +102,9 @@ type ScorecardAPI struct {
 	//   - application/json
 	JSONConsumer runtime.Consumer
 
+	// BinProducer registers a producer for the following mime types:
+	//   - image/svg+xml
+	BinProducer runtime.Producer
 	// JSONProducer registers a producer for the following mime types:
 	//   - application/json
 	JSONProducer runtime.Producer
@@ -184,6 +188,9 @@ func (o *ScorecardAPI) Validate() error {
 		unregistered = append(unregistered, "JSONConsumer")
 	}
 
+	if o.BinProducer == nil {
+		unregistered = append(unregistered, "BinProducer")
+	}
 	if o.JSONProducer == nil {
 		unregistered = append(unregistered, "JSONProducer")
 	}
@@ -243,6 +250,8 @@ func (o *ScorecardAPI) ProducersFor(mediaTypes []string) map[string]runtime.Prod
 	result := make(map[string]runtime.Producer, len(mediaTypes))
 	for _, mt := range mediaTypes {
 		switch mt {
+		case "image/svg+xml":
+			result["image/svg+xml"] = o.BinProducer
 		case "application/json":
 			result["application/json"] = o.JSONProducer
 		}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,6 +34,8 @@ x-google-allow: all
 paths:
   /projects/{platform}/{org}/{repo}/badge:
     get:
+      produces:
+        - image/svg+xml
       parameters:
         - in: query
           name: style


### PR DESCRIPTION
We were previously saying the `Content-Type` header for the badge was `application/json` which was causing issues for proxies (e.g. `go-camo` which is used by pypi).

E.g: https://pypi.org/project/numpy shows a broken OpenSSF Scorecard badge.