### PR TITLE
:bug: also check releases/v2 branch for github/codeql-action

### DIFF
--- a/app/server/verify_workflow.go
+++ b/app/server/verify_workflow.go
@@ -263,10 +263,16 @@ func (g *githubVerifier) contains(owner, repo, hash string) (bool, error) {
 	if contains {
 		return true, nil
 	}
-	// github/codeql-action has commits from their v1 release branch that don't show up in the default branch
+	// github/codeql-action has commits from their v1 and v2 release branch that don't show up in the default branch
 	// this isn't the best approach for now, but theres no universal "does this commit belong to this repo" call
 	if owner == "github" && repo == "codeql-action" {
-		contains, err = g.branchContains("releases/v1", owner, repo, hash)
+		contains, err = g.branchContains("releases/v2", owner, repo, hash)
+		if err != nil {
+			return false, err
+		}
+		if !contains {
+			contains, err = g.branchContains("releases/v1", owner, repo, hash)
+		}
 	}
 	return contains, err
 }

--- a/app/server/verify_workflow_test.go
+++ b/app/server/verify_workflow_test.go
@@ -115,14 +115,40 @@ func (s suffixStubTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-func Test_githubVerifier_contains(t *testing.T) {
+func Test_githubVerifier_contains_codeql_v1(t *testing.T) {
 	t.Parallel()
 	httpClient := http.Client{
 		Transport: suffixStubTripper{
 			responsePaths: map[string]string{
 				"codeql-action":   "./testdata/api/github/repository.json",     // api call which finds the default branch
 				"main...somehash": "./testdata/api/github/divergent.json",      // doesnt belong to default branch
+				"v2...somehash":   "./testdata/api/github/divergent.json",      // doesnt belong to releases/v2 branch
 				"v1...somehash":   "./testdata/api/github/containsCommit.json", // belongs to releases/v1 branch
+			},
+		},
+	}
+	client := github.NewClient(&httpClient)
+	gv := githubVerifier{
+		ctx:    context.Background(),
+		client: client,
+	}
+	got, err := gv.contains("github", "codeql-action", "somehash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != true {
+		t.Errorf("expected to contain hash, but it didnt")
+	}
+}
+
+func Test_githubVerifier_contains_codeql_v2(t *testing.T) {
+	t.Parallel()
+	httpClient := http.Client{
+		Transport: suffixStubTripper{
+			responsePaths: map[string]string{
+				"codeql-action":   "./testdata/api/github/repository.json",     // api call which finds the default branch
+				"main...somehash": "./testdata/api/github/divergent.json",      // doesnt belong to default branch
+				"v2...somehash":   "./testdata/api/github/containsCommit.json", // belongs to releases/v2 branch
 			},
 		},
 	}


### PR DESCRIPTION
This is a quick fix for the problem, and a proper fix can be investigated later. More details provided in https://www.github.com/github/codeql-action/issues/2040

Fixes #517 