### PR TITLE
:seedling: use Go 1.21 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   PROTOC_VERSION: 3.17.3
-  GO_VERSION: 1.18.5
+  GO_VERSION: 1.21
 
 jobs:
   build-scorecard-webapp:


### PR DESCRIPTION
1. Go 1.18 isn't supported
2. Should fix the issues in the latest group of dependabot PRs: (e.g #522). At least it does locally, testing with `act`