### PR TITLE
✨ Display maintainers annotation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -223,6 +223,11 @@ definitions:
         x-order: 4
         items:
           type: string
+      maintainersAnnotation:
+        type: array
+        x-order: 5
+        items:
+          type: string
 
   VerifiedScorecardResult:
     type: object

--- a/scorecards-site/static/viewer/index.html
+++ b/scorecards-site/static/viewer/index.html
@@ -931,6 +931,12 @@
                   <div class="text-muted detail-line">{{this}}</div>
                 {{/each}}
               {{/if}}
+              {{#if maintainersAnnotation}}
+                <div class="fw-semibold details-title">Maintainers Annotation</div>
+                {{#each maintainersAnnotation}}
+                  <div class="text-muted detail-line">{{this}}</div>
+                {{/each}}
+              {{/if}}
               <div class="link-wrapper">
                 <a class="btn-link fw-semibold" href="{{documentation.url}}" target="_blank" rel="noopener noreferrer">
                   <div class="d-flex flex-row align-items-center justify-content-end">


### PR DESCRIPTION
The annotations are displayed inside the check collapsible component, after the reason and details, as "Maintainers Annotation". Then, we list the human-readable annotations for that check based on the label annotations given by the maintainer in scorecard.yml file.

(For this field to come, first the JSON output in ossf/scorecard needs to introduce the maintainers annotation field).

Related to: https://github.com/ossf/scorecard/pull/3905