### PR TITLE
:seedling: group dependabot updates for go-openapi dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     reviewers:
       - "ossf/scorecard-maintainers"
     open-pull-requests-limit: 10
+    groups:
+      go-openapi:
+        patterns:
+          - "github.com/go-openapi/*"
   # For the website code in scorecards-site.
   - package-ecosystem: npm
     directory: '/'


### PR DESCRIPTION
these dependencies are released at the same time and generate 8+ PRs. After grouping it should just be one PR going forward.

See #575 through #585
https://github.com/ossf/scorecard-webapp/issues?q=go-openapi+is%3Aclosed+author%3Aapp%2Fdependabot+created%3A2024-03-10..2024-03-12
