### PR TITLE
:bug: check github/codeql-action releases/v3 branch explicitly.

### DIFF
--- a/app/server/verify_workflow.go
+++ b/app/server/verify_workflow.go
@@ -265,15 +265,18 @@ func (g *githubVerifier) contains(owner, repo, hash string) (bool, error) {
 	}
 
 	switch {
-	// github/codeql-action has commits from their v1 and v2 release branch that don't show up in the default branch
+	// github/codeql-action has commits from their release branches that don't show up in the default branch
 	// this isn't the best approach for now, but theres no universal "does this commit belong to this repo" call
 	case owner == "github" && repo == "codeql-action":
-		contains, err = g.branchContains("releases/v2", owner, repo, hash)
-		if err != nil {
-			return false, err
-		}
-		if !contains {
-			contains, err = g.branchContains("releases/v1", owner, repo, hash)
+		releaseBranches := []string{"releases/v3", "releases/v2", "releases/v1"}
+		for _, branch := range releaseBranches {
+			contains, err = g.branchContains(branch, owner, repo, hash)
+			if err != nil {
+				return false, err
+			}
+			if contains {
+				return true, nil
+			}
 		}
 
 	// add fallback lookup for actions/upload-artifact v3/node20 branch

--- a/app/server/verify_workflow_test.go
+++ b/app/server/verify_workflow_test.go
@@ -122,6 +122,7 @@ func Test_githubVerifier_contains_codeql_v1(t *testing.T) {
 			responsePaths: map[string]string{
 				"codeql-action":   "./testdata/api/github/repository.json",     // api call which finds the default branch
 				"main...somehash": "./testdata/api/github/divergent.json",      // doesnt belong to default branch
+				"v3...somehash":   "./testdata/api/github/divergent.json",      // doesnt belong to releases/v3 branch
 				"v2...somehash":   "./testdata/api/github/divergent.json",      // doesnt belong to releases/v2 branch
 				"v1...somehash":   "./testdata/api/github/containsCommit.json", // belongs to releases/v1 branch
 			},
@@ -148,6 +149,7 @@ func Test_githubVerifier_contains_codeql_v2(t *testing.T) {
 			responsePaths: map[string]string{
 				"codeql-action":   "./testdata/api/github/repository.json",     // api call which finds the default branch
 				"main...somehash": "./testdata/api/github/divergent.json",      // doesnt belong to default branch
+				"v3...somehash":   "./testdata/api/github/divergent.json",      // doesnt belong to releases/v3 branch either
 				"v2...somehash":   "./testdata/api/github/containsCommit.json", // belongs to releases/v2 branch
 			},
 		},


### PR DESCRIPTION
The release process for that action creates a time window where commits exist in releases/v3 before they get merged back into main. This led to imposter commit timing issues when users were merging updates.

Fixes https://github.com/ossf/scorecard-action/issues/1367