### PR TITLE
Remove link to closed survey

### DIFF
--- a/scorecards-site/content/home.md
+++ b/scorecards-site/content/home.md
@@ -149,7 +149,7 @@ That’s where Security Scorecards *[i.e., OpenSSF Scorecard]* is helping. Its f
 
 ### What is OpenSSF Scorecard?
 
-##### Scorecard assesses open source projects for security risks through a series of automated checks
+##### Scorecard assesses open source projects for security risks through a series of automated checks.
 
 It was created by OSS developers to help improve the health of critical projects that the community depends on.
 

--- a/scorecards-site/pages/index.vue
+++ b/scorecards-site/pages/index.vue
@@ -4,9 +4,6 @@
       class="flex justify-center items-center relative min-h-mobile md:min-h-threeQuarters"
     >
       <div class="mx-auto w-full md:w-4/6 text-center hero-text">
-        <div class="pt-20 pb-32 text-22">
-          Take the <a href="https://forms.gle/aqxZwmVQzWJkNuso8">OpenSSF Scorecard User Survey</a>
-        </div>
         <h1>
           Build better security habits,<br />
           one test at a time


### PR DESCRIPTION
Removed link to survey because it is closed now.

Added a period at the end of the response sentence in the What is OpenSSF Scorecard? section.