### PR TITLE
:book: update api links to new scorecard.dev site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # OpenSSF Scorecard API and website
 
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ossf/scorecard-webapp/badge)](https://api.securityscorecards.dev/projects/github.com/ossf/scorecard-webapp)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ossf/scorecard-webapp/badge)](https://api.scorecard.dev/projects/github.com/ossf/scorecard-webapp)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/d631bbe2-0e67-48ae-81a7-d7015195c9fd/deploy-status)](https://app.netlify.com/sites/ossf-scorecard/deploys)
 
 ## scorecard-webapp
 
-Code for https://securityscorecards.dev
+Code for https://scorecard.dev
 ([`./scorecards-site`](./scorecards-site)) and
-https://api.securityscorecards.dev ([`./app`](./app)).
+https://api.scorecard.dev ([`./app`](./app)).
 
 The site is deployed on Netlify and the deployment configuration is in
 [netlify.toml](./netlify.toml). Any changes committed to

--- a/app/generated/client/open_ssf_scorecard_api_client.go
+++ b/app/generated/client/open_ssf_scorecard_api_client.go
@@ -35,7 +35,7 @@ var Default = NewHTTPClient(nil)
 const (
 	// DefaultHost is the default Host
 	// found in Meta (info) section of spec file
-	DefaultHost string = "api.securityscorecards.dev"
+	DefaultHost string = "api.scorecard.dev"
 	// DefaultBasePath is the default BasePath
 	// found in Meta (info) section of spec file
 	DefaultBasePath string = "/"

--- a/app/generated/restapi/doc.go
+++ b/app/generated/restapi/doc.go
@@ -19,7 +19,7 @@
 //	API to interact with a project's published Scorecard result
 //	Schemes:
 //	  http
-//	Host: api.securityscorecards.dev
+//	Host: api.scorecard.dev
 //	BasePath: /
 //	Version: 1.0.0
 //

--- a/app/generated/restapi/embedded_spec.go
+++ b/app/generated/restapi/embedded_spec.go
@@ -48,7 +48,7 @@ func init() {
     "title": "OpenSSF Scorecard API",
     "version": "1.0.0"
   },
-  "host": "api.securityscorecards.dev",
+  "host": "api.scorecard.dev",
   "paths": {
     "/projects/{platform}/{org}/{repo}": {
       "get": {
@@ -370,7 +370,7 @@ func init() {
     "title": "OpenSSF Scorecard API",
     "version": "1.0.0"
   },
-  "host": "api.securityscorecards.dev",
+  "host": "api.scorecard.dev",
   "paths": {
     "/projects/{platform}/{org}/{repo}": {
       "get": {

--- a/app/generated/restapi/static/swagger-initializer.js
+++ b/app/generated/restapi/static/swagger-initializer.js
@@ -12,7 +12,7 @@ window.onload = function() {
 
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle({
-    url: "https://api.securityscorecards.dev/swagger.json",
+    url: "https://api.scorecard.dev/swagger.json",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17,7 +17,7 @@ info:
   title: OpenSSF Scorecard API
   description: API to interact with a project's published Scorecard result
   version: 1.0.0
-host: api.securityscorecards.dev
+host: api.scorecard.dev
 schemes:
   - http
 

--- a/scorecards-site/static/viewer/index.html
+++ b/scorecards-site/static/viewer/index.html
@@ -1,7 +1,7 @@
 <!--
   OpenSSF Scorecard result viewer
 
-  This page fetches the OpenSSF Scorecard result requested from https://api.securityscorecards.dev
+  This page fetches the OpenSSF Scorecard result requested from https://api.scorecard.dev
   and displays it nicely.
 
   Its behavior can be controlled with the following query string parameters:


### PR DESCRIPTION
As mentioned in our blog post, and in slack, we're favoring scorecard.dev instead of securityscorecards.dev https://openssf.org/blog/2024/03/05/openssf-scorecard-evaluating-and-improving-the-health-of-critical-oss-projects/