### PR TITLE
:seedling: allow ghcr docker images

### DIFF
--- a/app/server/verify_workflow.go
+++ b/app/server/verify_workflow.go
@@ -182,7 +182,7 @@ func verifyScorecardWorkflow(workflowContent string, verifier commitVerifier) er
 				}
 			}
 		// Needed for e2e tests
-		case "gcr.io/openssf/scorecard-action":
+		case "gcr.io/openssf/scorecard-action", "ghcr.io/ossf/scorecard-action":
 		default:
 			return verificationError{e: fmt.Errorf("%w: %s", errUnallowedStepName, stepName)}
 		}


### PR DESCRIPTION
With the switch to GHCR we'll need to support both images for e2e testing. Eventually we can remove the gcr.io case if needed.

https://github.com/ossf/scorecard-action/pull/1453