### PR TITLE
specify golangci-lint version explicitly in lint workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ on:
 env:
   PROTOC_VERSION: 3.17.3
   GO_VERSION: 1.23
+  GOLANGCI_LINT_VERSION: v1.63
 
 jobs:
   build-scorecard-webapp:
@@ -48,6 +49,7 @@ jobs:
        uses: golangci/golangci-lint-action@051d91933864810ecd5e2ea2cfd98f6a5bca5347 # v6.3.2
        with:
          args: --config=.golangci.yml
+         version: ${{ env.GOLANGCI_LINT_VERSION }}
      - name: Check license headers
        run: |
           go env -w GOFLAGS=-mod=mod


### PR DESCRIPTION
By default, the action uses `latest`, which can cause new issues to appear independent of any code changes in this repository.

This issue is blocking #740 for example, because v1.64 was released