### PR TITLE
fix GitHub markdown rendering by removing space from badge style

### DIFF
--- a/app/server/badge.go
+++ b/app/server/badge.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	shieldsURL   = "https://img.shields.io/ossf-scorecard"
-	badgeLabel   = "openssf scorecard"
+	badgeLabel   = "openssf+scorecard"
 	defaultStyle = "flat"
 )
 


### PR DESCRIPTION
Related to https://github.com/ossf/scorecard/issues/4591

While the redirect was working locally with curl, I suspect the space may be causing issues with GitHub's camo proxy. This suspicion is due to a test README I did which directly linked failed to render:

    ![image](https://img.shields.io/<...>label=openssf scorecard<...>

But using the plus seemed to render.

    ![image](https://img.shields.io/<...>label=openssf+scorecard<...>