### PR TITLE
Allow `actions/create-github-app-token` for generating the necessary token from a GitHub App

### DIFF
--- a/app/server/verify_workflow.go
+++ b/app/server/verify_workflow.go
@@ -165,6 +165,7 @@ func verifyScorecardWorkflow(workflowContent string, verifier commitVerifier) er
 		switch stepName {
 		case
 			"actions/checkout",
+			"actions/create-github-app-token",
 			"ossf/scorecard-action",
 			"actions/upload-artifact",
 			"github/codeql-action/upload-sarif",


### PR DESCRIPTION
E.g. https://github.com/open-telemetry/opentelemetry-java-contrib/blob/b3a3b2cd17e2d2d30589872bb535ede9029844ec/.github/workflows/ossf-scorecard.yml#L26-L33