### PR TITLE
viewer: show checks missing from API with a ?

### DIFF
--- a/scorecards-site/static/viewer/index.html
+++ b/scorecards-site/static/viewer/index.html
@@ -1351,6 +1351,16 @@
 
         apiFetch(platform, org, repo, params.commit)
           .then((data) => {
+            const presentCheckNames = data.checks.map(c => c.name);
+            PLACEHOLDER.checks.forEach(placeholderCheck => {
+              if (!presentCheckNames.includes(placeholderCheck.name)) {
+                data.checks.push({
+                  ...placeholderCheck,
+                  score: -1,
+                  reason: "Check not found in API response"
+                });
+              }
+            });
             scoreData = data;
             renderDataTemplate({ data: {...data, checks: sortChecks(data.checks)}, apiURL: apiURL, isPlaceholder: false, sortBy: sortBy, sortDirection: sortDirection });
           })


### PR DESCRIPTION
Missing checks in the viewer are a common source of confusion among users. This approach was suggested in 
https://github.com/ossf/scorecard/issues/3648#issuecomment-1877262030