### PR TITLE
migrate dependabot reviewers to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ossf/scorecard-maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       interval: daily
     commit-message:
       prefix: ":seedling:"
-    reviewers:
-      - "ossf/scorecard-maintainers"
     open-pull-requests-limit: 10
     groups:
       go-openapi:
@@ -21,8 +19,6 @@ updates:
       interval: daily
       time: '00:00'
     open-pull-requests-limit: 10
-    reviewers:
-      - "ossf/scorecard-maintainers"
     commit-message:
       prefix: fix
       prefix-development: chore
@@ -34,8 +30,6 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: ":seedling:"
-    reviewers:
-      - "ossf/scorecard-maintainers"
     groups:
       github-actions:
         patterns:
@@ -47,6 +41,4 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: ":seedling:"
-    reviewers:
-      - "ossf/scorecard-maintainers"
     open-pull-requests-limit: 10


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/