### PR TITLE
Match Ubuntu runner labels by pattern, not a fixed list

### DIFF
--- a/app/server/verify_workflow.go
+++ b/app/server/verify_workflow.go
@@ -46,15 +46,18 @@ var (
 	reCommitSHA = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
 )
 
-// TODO(#290): retrieve the runners dynamically.
-// List below is from https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners.
-var ubuntuRunners = map[string]bool{
-	"ubuntu-latest": true,
-	"ubuntu-24.04":  true,
-	"ubuntu-22.04":  true,
-	"ubuntu-20.04":  true,
-	"ubuntu-18.04":  true,
-}
+// ubuntuRunnerRe matches the labels for GitHub-hosted Ubuntu runners, e.g.
+// "ubuntu-latest", "ubuntu-24.04", and their "-arm" variants. Matching a
+// pattern instead of a hand-maintained allowlist (#290) avoids the recurring
+// breakage when GitHub ships a new image, which surfaced as opaque publishing
+// failures in ossf/scorecard-action#910, #1381, and #1684.
+// See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners.
+var ubuntuRunnerRe = regexp.MustCompile(`^ubuntu-(latest|\d{2}\.\d{2})(-arm)?$`)
+
+// minUbuntuVersion is the oldest GitHub-hosted Ubuntu image we accept. Older
+// images (e.g. 18.04, 20.04) are end-of-life on GitHub-hosted runners. Version
+// labels are fixed-width "YY.MM", so lexical comparison matches numeric order.
+const minUbuntuVersion = "22.04"
 
 type commit struct {
 	owner, repo, hash string
@@ -138,8 +141,11 @@ func verifyScorecardWorkflow(workflowContent string, verifier commitVerifier) er
 		return verificationError{e: errScorecardJobRunsOn}
 	}
 	label := labels[0].Value
-	if _, ok := ubuntuRunners[label]; !ok {
-		return fmt.Errorf("%w: '%s'", errInvalidRunnerLabel, label)
+	if !isSupportedUbuntuRunner(label) {
+		// Wrap in verificationError so an unsupported runner is reported as a
+		// 400 Bad Request (client input error) rather than a 500 (see
+		// PostResultsHandler).
+		return verificationError{e: fmt.Errorf("%w: '%s'", errInvalidRunnerLabel, label)}
 	}
 
 	// Verify that there are no job env vars set.
@@ -250,6 +256,21 @@ func getStepUses(step *actionlint.Step) *actionlint.String {
 
 func isCommitHash(s string) bool {
 	return reCommitSHA.MatchString(s)
+}
+
+// isSupportedUbuntuRunner reports whether label is a GitHub-hosted Ubuntu
+// runner at or above minUbuntuVersion. "ubuntu-latest" always tracks a
+// currently-supported image and is accepted.
+func isSupportedUbuntuRunner(label string) bool {
+	m := ubuntuRunnerRe.FindStringSubmatch(label)
+	if m == nil {
+		return false
+	}
+	version := m[1]
+	if version == "latest" {
+		return true
+	}
+	return version >= minUbuntuVersion
 }
 
 func hasServices(j *actionlint.Job) bool {

--- a/app/server/verify_workflow_test.go
+++ b/app/server/verify_workflow_test.go
@@ -92,6 +92,56 @@ func TestVerifyInvalidWorkflows(t *testing.T) {
 	}
 }
 
+func TestVerifyRunnerLabels(t *testing.T) {
+	t.Parallel()
+	// Start from a known-valid workflow and swap only the runs-on label so each
+	// case exercises the runner-label check in isolation.
+	base, err := os.ReadFile("testdata/workflow-valid.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const origLabel = "runs-on: ubuntu-latest"
+	if !strings.Contains(string(base), origLabel) {
+		t.Fatalf("fixture no longer contains %q; update this test", origLabel)
+	}
+
+	tests := []struct {
+		label   string
+		wantErr bool
+	}{
+		{label: "ubuntu-latest", wantErr: false},
+		{label: "ubuntu-latest-arm", wantErr: false},
+		{label: "ubuntu-22.04", wantErr: false},
+		{label: "ubuntu-24.04", wantErr: false},
+		{label: "ubuntu-26.04", wantErr: false}, // ossf/scorecard-action#1684
+		{label: "ubuntu-22.04-arm", wantErr: false},
+		{label: "ubuntu-24.04-arm", wantErr: false},
+		{label: "ubuntu-20.04", wantErr: true}, // end-of-life, below minimum
+		{label: "ubuntu-18.04", wantErr: true}, // end-of-life, below minimum
+		{label: "macos-13", wantErr: true},
+		{label: "self-hosted", wantErr: true},
+		{label: "ubuntu-", wantErr: true},
+		{label: "Ubuntu-latest", wantErr: true}, // labels are case-sensitive
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.label, func(t *testing.T) {
+			t.Parallel()
+			content := strings.Replace(string(base), origLabel, "runs-on: "+tt.label, 1)
+			err := verifyScorecardWorkflow(content, allowCommitVerifier)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			// An unsupported runner must surface as a verificationError wrapping
+			// errInvalidRunnerLabel so the API returns 400, not 500.
+			assert.ErrorIs(t, err, errInvalidRunnerLabel)
+			var vErr verificationError
+			assert.ErrorAs(t, err, &vErr)
+		})
+	}
+}
+
 // suffix may not be the best term, but maps the final part of a path to a response file.
 // this is helpful when multiple API calls need to be made.
 // e.g. a call to /foo/bar/some/endpoint would have "endpoint" as a suffix.


### PR DESCRIPTION
## What this does

Workflow verification currently allow-lists GitHub-hosted Ubuntu runners
with a hand-maintained map (the `TODO(#290)`). Each time GitHub ships a new
Ubuntu image, the map goes stale and publishing fails with an opaque
`500 Internal Server Error` until someone hand-adds a line. This has recurred
at least three times downstream in scorecard-action:

- ossf/scorecard-action#910 (ubuntu-22.04)
- ossf/scorecard-action#1381 (ubuntu-24.04)
- ossf/scorecard-action#1684 (ubuntu-26.04, still open)

This replaces the map with a pattern match plus a minimum-version floor, and
fixes the incorrect status code so an unsupported runner is a clear `400`.

## Changes

- **Pattern instead of a list** — `^ubuntu-(latest|\d{2}\.\d{2})(-arm)?$`, so
  new images (and the `-arm` GitHub-hosted variants, missing today) are
  accepted without code changes. Unblocks `ubuntu-26.04`.
- **Minimum version floor** — reject images older than `ubuntu-22.04`.
  `18.04` and `20.04` are end-of-life on GitHub-hosted runners. **Note: this
  is a deliberate tightening** — those two labels were accepted before and now
  return `400`.
- **500 → 400** — the invalid-runner error was returned bare, so
  `PostResultsHandler` fell through to `500`. It is now wrapped in
  `verificationError`, mapping an unsupported runner to `400 Bad Request` with
  an actionable message (this is why each occurrence generated duplicate bug
  reports).
- **Tests** — table-driven coverage for accepted/rejected labels, including
  `ubuntu-26.04`, `-arm` variants, EOL versions, and non-Ubuntu/self-hosted
  labels, asserting the reject path surfaces as `verificationError`
  (i.e. `400`).

## Note for reviewers on the security intent

The allow-list exists to steer results toward trusted GitHub-hosted Ubuntu
runners. Worth being explicit: the runner-**label** check is not a hard trust
boundary — a self-hosted runner can carry an arbitrary label, so real
provenance comes from the Fulcio/OIDC/Rekor verification, not this string.
Relaxing an exact list to a pattern does not broaden trust in practice: a
label like `ubuntu-99.99` can't produce a valid signed result because GitHub
would reject the runner before the job runs. This is a pre-existing limitation
of label-based checks, flagged here rather than silently expanded — happy to
adjust the floor or the pattern if maintainers prefer a different posture.

Fixes #290
