### PR TITLE
fix(viewer): handle empty scorecard reports

### DIFF
--- a/scorecards-site/static/viewer/index.html
+++ b/scorecards-site/static/viewer/index.html
@@ -1581,6 +1581,11 @@
         const response = await fetch(apiURL)
         if (response.ok) {
           const data = await response.json()
+          if (!Array.isArray(data.checks) || data.checks.length === 0) {
+            throw {
+              status: 404,
+            }
+          }
           return data
         } else {
           if (response.status === 404) {


### PR DESCRIPTION
## Summary

- Treat successful API payloads with missing or empty `checks` as reports that were not found.
- Reuse the viewer's existing 404 presentation instead of allowing `sortChecks()` to throw on `null` and display `Status code: undefined`.

Fixes #779.

## Verification

Tested the viewer in headless Firefox against the live public API:

- `github.com/goiiot/libmqtt` (`HTTP 200`, `score: -1`, `checks: null`) renders **The Scorecard report requested was not found**.
- `github.com/ossf/scorecard` renders normally with score `9.0`.
- No browser page errors were emitted.
- `git diff --check` passes.

Formatting note: `prettier@3.9.6 --check` also reports the unmodified upstream version of this HTML file as needing formatting, so I kept this PR to the five-line behavioral fix rather than reformatting the full 1,600-line file.