### PR TITLE
fix(viewer): sort checks by name within risk levels

### DIFF
--- a/scorecards-site/static/viewer/index.html
+++ b/scorecards-site/static/viewer/index.html
@@ -1551,7 +1551,7 @@
                 ...CHECKS_WITH_VALUE.sort(
                   (a, b) =>
                     getRiskLevelValue(b.name) - getRiskLevelValue(a.name) ||
-                    parseFloat(a.score) - parseFloat(b.score),
+                    a.name.localeCompare(b.name),
                 ),
                 ...sortedChecksWithoutValue,
               ]
@@ -1560,7 +1560,7 @@
                 ...CHECKS_WITH_VALUE.sort(
                   (a, b) =>
                     getRiskLevelValue(a.name) - getRiskLevelValue(b.name) ||
-                    parseFloat(a.score) - parseFloat(b.score),
+                    a.name.localeCompare(b.name),
                 ),
                 ...sortedChecksWithoutValue,
               ]


### PR DESCRIPTION
## Summary

- keep risk level as the primary viewer sort key
- sort checks alphabetically by name within each risk category
- preserve the existing behavior that places inconclusive checks at the bottom

## Why

The risk-level comparator currently uses numeric score as its tie-breaker, so checks in the same risk category appear in an inconsistent, non-alphabetical order. Using the check name as the tie-breaker makes the result predictable while preserving the selected risk-level direction.

Fixes #430.

## Verification

- focused Node assertions cover ascending and descending risk-level ordering and confirm inconclusive checks remain last
- `git diff --check`

The viewer does not currently have a dedicated unit-test suite for this inline comparator.
