### PR TITLE
fix(site): use available width for homepage content

### DIFF
--- a/scorecards-site/content/home.md
+++ b/scorecards-site/content/home.md
@@ -10,7 +10,7 @@ thumbnail: /assets/checks.png
   <sidebar ref="sideBar" class="sticky top-60 h-400 min-w-max w-1/3 hidden md:block mr-80"></sidebar>
 </div>
 
-<section class="bg-orange prose md:prose-lg w-full">
+<section class="bg-orange prose md:prose-lg w-full" style="max-width: none">
 
 <h2 class="h1" id="run-the-checks">Run the checks</h2>
 


### PR DESCRIPTION
## Summary
- Fixes #5182.
- Allow the homepage guide content to use its parent container width instead of Tailwind Typography's default prose max-width.

## Validation
- Reproduced the issue on scorecard.dev at a 1280px viewport: the outer content container was 1200px wide while the prose section was about 398px wide.
- Ran git diff --check.
- Used Node 22.23.2 locally. The repository-wide Prettier check reports pre-existing formatting differences across 64 files, including files outside this change. The targeted home.md check also fails against the existing file style.
- Started yarn build under Node 22; it did not produce output after more than five minutes in this environment, so this PR is a draft pending upstream CI.