### PR TITLE
fix(site): preserve homepage desktop content layout

### DIFF
--- a/scorecards-site/pages/index.vue
+++ b/scorecards-site/pages/index.vue
@@ -77,7 +77,7 @@
       <ContentRenderer
         v-if="page"
         ref="nuxtContent"
-        class="nuxt-content"
+        class="nuxt-content w-full md:flex"
         :value="page"
       />
     </div>
@@ -249,4 +249,11 @@ export default {
   },
 }
 </script>
-<style lang="scss"></style>
+<style lang="scss">
+@media (min-width: 768px) {
+  .nuxt-content > div {
+    display: flex;
+    width: 100%;
+  }
+}
+</style>


### PR DESCRIPTION
Fixes ossf/scorecard#5196\n\nThe Nuxt Content renderer adds a wrapper around the homepage Markdown. After the Nuxt 3 migration, that wrapper became the only flex child, so the navigation and main content no longer participated directly in the desktop layout.\n\nThis keeps the renderer wrapper full-width and makes its generated child a desktop flex container, restoring the intended two-column structure without removing the rendered content.\n\nValidation:\n- \yarn build\ with Node 22 in GitHub Codespaces\n- Verified homepage content renders in the desktop preview